### PR TITLE
update sts dockerfile python image

### DIFF
--- a/devops/dockerfiles/sts/Dockerfile
+++ b/devops/dockerfiles/sts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-alpine3.21 AS fnl_base_image
+FROM python:3.13.4-alpine3.22 AS fnl_base_image
 EXPOSE 5000/tcp
 ENV NEO4J_MDB_URI=bolt://localhost:7687 \
     NEO4J_MDB_USER=neo4j \


### PR DESCRIPTION
Updated base python image in sts dockerfile to use python:3.13.4-alpine3.22 instead of python:3.13.3-alpine3.21 which installs pip 25.1.1 instead of pip 25.0.1 in attempt to fix this vulnerability