### PR TITLE
Fix EDP changelog upload gating

### DIFF
--- a/.github/workflows/generate_edp_changelog.yml
+++ b/.github/workflows/generate_edp_changelog.yml
@@ -77,6 +77,7 @@ jobs:
           uv sync --all-extras --dev
 
       - name: Generate EDP Changelog
+        id: generate
         run: |
           mkdir -p data/output/edp_changelogs/
 
@@ -85,16 +86,27 @@ jobs:
             TERMS_ARGS="$TERMS_ARGS --terms_files $f"
           done
 
+          OUTPUT_FILE="data/output/edp_changelogs/edp_changelog_${{ github.run_id }}.xml"
+
           make_edp_changelog \
             --edp_yaml_files edp-repo/model-desc/edp-props.yml \
             $TERMS_ARGS \
             --edp_config_file config/mdb_edps.yml \
-            --output_file data/output/edp_changelogs/edp_changelog_${{ github.run_id }}.xml \
+            --output_file "$OUTPUT_FILE" \
             --author "GitHub Actions" \
             --_commit "${{ github.sha }}"
 
+          if ! grep -q "<changeSet" "$OUTPUT_FILE"; then
+            echo "No EDP changesets generated; skipping upload."
+            rm -f "$OUTPUT_FILE"
+            echo "has_changelog=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changelog=true" >> "$GITHUB_OUTPUT"
+
       - name: AWS OIDC Authentication
-        if: ${{ !fromJson(github.event.inputs.no_commit || 'false') }}
+        if: ${{ !fromJson(github.event.inputs.no_commit || 'false') && steps.generate.outputs.has_changelog == 'true' }}
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
@@ -103,23 +115,23 @@ jobs:
 
       - name: Upload EDP changelog to S3
         id: upload
-        if: ${{ !fromJson(github.event.inputs.no_commit || 'false') }}
+        if: ${{ !fromJson(github.event.inputs.no_commit || 'false') && steps.generate.outputs.has_changelog == 'true' }}
         run: |
           S3_KEY="external_ont_changelogs/edp_changelog_${{ github.run_id }}.xml"
           aws s3 cp data/output/edp_changelogs/edp_changelog_${{ github.run_id }}.xml \
             "s3://${S3_BUCKET}/${S3_KEY}" \
             --content-type application/xml
-          echo "s3_keys=[\"${S3_KEY}\"]" >> $GITHUB_OUTPUT
+          echo "s3_keys=[\"${S3_KEY}\"]" >> "$GITHUB_OUTPUT"
           echo "Uploaded: $S3_KEY"
 
       - name: Commit S3 upload log
-        if: ${{ !fromJson(github.event.inputs.no_commit || 'false') && steps.upload.outputs.s3_keys != '' }}
+        if: ${{ !fromJson(github.event.inputs.no_commit || 'false') && steps.generate.outputs.has_changelog == 'true' && steps.upload.outputs.s3_keys != '' }}
         env:
           RUN_ID: ${{ github.run_id }}
         run: |
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "actions@github.com"
           git pull origin ${{ github.ref_name }}
-          COMMIT_MSG="s3-upload-log run=${RUN_ID} keys=${{ steps.upload.outputs.s3_keys }}"
+          COMMIT_MSG=$(printf 's3-upload-log run=%s keys=%s' "$RUN_ID" '${{ steps.upload.outputs.s3_keys }}')
           git commit --allow-empty -m "$COMMIT_MSG"
           git push origin ${{ github.ref_name }}

--- a/scripts/make_edp_changelog.py
+++ b/scripts/make_edp_changelog.py
@@ -79,11 +79,11 @@ def _filter_edp_definitions_from_config(
     config = _load_yaml(edp_config_file)
     allowed = {
         (
-            spec.get("prop_definition"),
+            spec.get("property"),
             str(spec.get("latest_version")),
         )
         for spec in config.values()
-        if spec.get("prop_definition") and spec.get("latest_version") is not None
+        if spec.get("property") and spec.get("latest_version") is not None
     }
 
     filtered = []

--- a/tests/test_edp_changelog.py
+++ b/tests/test_edp_changelog.py
@@ -244,7 +244,7 @@ class TestGenerateEdpChangelog:
                 {
                     "OBIB": {
                         "latest_version": "2",
-                        "prop_definition": "obib_terms_valueset",
+                        "property": "obib_terms_valueset",
                     },
                 },
                 sort_keys=False,


### PR DESCRIPTION
This PR updates the EDP changelog generation workflow to:

- skip S3 upload when the generated changelog contains no <changeSet>
- avoid creating an upload-log commit when there is no changelog to process
- preserve the S3 key list as valid JSON for downstream update workflows
- align EDP changelog filtering with the new property config key in config/mdb_edps.yml

Focused tests were run for the EDP changelog and EDP version-check paths.