### PR TITLE
DATATEAM-661 - Add test model to MDB update workflow

### DIFF
--- a/config/mdb_models.yml
+++ b/config/mdb_models.yml
@@ -6,6 +6,32 @@ C3DC:
   - c3dc-model-props.yml
   in_data_hub: false
   versions:
+  - version: 1.0.0
+    tag: 1.0.0
+  - version: 1.0.1
+    tag: 1.0.1
+  - version: 1.0.2
+    tag: 1.0.2
+  - version: 1.0.3
+    tag: 1.0.3
+  - version: 1.0.4
+    tag: 1.0.4
+  - version: 1.0.5
+    tag: 1.0.5
+  - version: 1.0.6
+    tag: 1.0.6
+  - version: 1.0.7
+    tag: 1.0.7
+  - version: 1.0.8
+    tag: 1.0.8
+  - version: 1.1.0
+    tag: 1.1.0
+  - version: 1.1.1
+    tag: 1.1.1
+  - version: 1.2.0
+    tag: 1.2.0
+  - version: 1.3.0
+    tag: 1.3.0
   - version: 1.4.0
     tag: 1.4.0
   - version: 2.0.0
@@ -51,6 +77,56 @@ CCDI:
   - terms.yml
   in_data_hub: true
   versions:
+  - version: 1.0.2
+    tag: 1.0.2
+  - version: 1.0.3
+    tag: 1.0.3
+  - version: 1.0.4
+    tag: 1.0.4
+  - version: 1.0.5
+    tag: 1.0.5
+  - version: 1.0.6
+    tag: 1.0.6
+  - version: 1.1.0
+    tag: 1.1.0
+  - version: 1.1.1
+    tag: 1.1.1
+  - version: 1.1.2
+    tag: 1.1.2
+  - version: 1.1.3
+    tag: 1.1.3
+  - version: 1.1.4
+    tag: 1.1.4
+  - version: 1.2.0
+    tag: 1.2.0
+  - version: 1.3.0
+    tag: 1.3.0
+  - version: 1.3.1
+    tag: 1.3.1
+  - version: 1.4.0
+    tag: 1.4.0
+  - version: 1.4.1
+    tag: 1.4.1
+  - version: 1.5.0
+    tag: 1.5.0
+  - version: 1.5.1
+    tag: 1.5.1
+  - version: 1.5.2
+    tag: 1.5.2
+  - version: 1.6.0
+    tag: 1.6.0
+  - version: 1.6.1
+    tag: 1.6.1
+  - version: 1.7.0
+    tag: 1.7.0
+  - version: 1.7.1
+    tag: 1.7.1
+  - version: 1.7.2
+    tag: 1.7.2
+  - version: 1.8.0
+    tag: 1.8.0
+  - version: 1.9.0
+    tag: 1.9.0
   - version: 1.9.1
     tag: 1.9.1
   - version: 2.0.0
@@ -91,6 +167,8 @@ CDS:
   in_data_hub: true
   versions:
   - version: 1.1.0
+  - version: 1.2.0
+    tag: 1.2.0
   - version: 1.3.0
   - version: 2.1.0
   - version: 3.1.2
@@ -103,6 +181,8 @@ CDS:
     tag: 4.0.3-CDS-Release
   - version: 4.0.4
     tag: 4.0.4-CDS_Release
+  - version: 5.0.0
+    tag: 5.0.0-CDS_Release
   - version: 5.0.1
     tag: 5.0.1-CDS_Release
   - version: 5.0.2
@@ -111,6 +191,8 @@ CDS:
     tag: 5.0.3-CDS_Release
   - version: 5.0.4
     tag: 5.0.4-CDS_Release
+  - version: 5.0.5
+    tag: 5.0.5-CDS_Release
   - version: 6.0.0
   - version: 6.0.1
     tag: 6.0.1-CDS_Release
@@ -147,7 +229,7 @@ CDS:
   - version: 11.0.4
     tag: 11.0.4-GC_Release
   latest_version: 11.0.4
-  latest_prerelease_commit: 3cd0ae2ab7d66c435883062fcae8e054813155e1
+  latest_prerelease_commit: 0fea351c3cee88c246b14ab4f69929f12ebd08a1
   latest_prerelease_version: 12.0.0
 CTDC:
   repository: CBIIT/ctdc-model
@@ -213,7 +295,9 @@ CTDC:
     tag: 2.1.0
   - version: 3.0.0
     tag: 3.0.0
-  latest_version: 3.0.0
+  - version: 3.1.0
+    tag: 3.1.0
+  latest_version: 3.1.0
   latest_prerelease_commit: 37ea2af1bfad31d12b48f2335f563f14cf215fb2
   latest_prerelease_version: 3.1.0
 GDC:
@@ -225,6 +309,8 @@ GDC:
   - gdc-model-terms.yaml
   in_data_hub: false
   versions:
+  - version: 0.1.0
+    tag: mdf.0.1.0
   - version: 3.0.3
   latest_version: 3.0.3
   latest_prerelease_commit: null
@@ -302,6 +388,8 @@ PSDC:
   - popsci-model-props.yml
   in_data_hub: true
   versions:
+  - version: 0.0.1
+    tag: 0.0.1
   - version: 1.0.0
     tag: 1.0.0
   latest_version: 1.0.0
@@ -311,13 +399,12 @@ TEST:
   repository: CBIIT/ctos-test-model
   mdf_directory: model-desc
   mdf_files:
-    - test-model.yml
-    - test-model-props.yml
+  - test-model.yml
+  - test-model-props.yml
   in_data_hub: false
   versions:
-    - version: 1.0.0
-      tag: 1.0.0
+  - version: 1.0.0
+    tag: 1.0.0
   latest_version: 1.0.0
   latest_prerelease_commit: null
   latest_prerelease_version: null
-  

--- a/config/mdb_models.yml
+++ b/config/mdb_models.yml
@@ -405,6 +405,6 @@ TEST:
   versions:
   - version: 1.0.0
     tag: 1.0.0
-  latest_version: 1.0.0
-  latest_prerelease_commit: null
-  latest_prerelease_version: null
+  latest_version: null
+  latest_prerelease_commit: 277d1c56e41bdec9e03947804e997ca66656477e
+  latest_prerelease_version: 1.0.0

--- a/config/mdb_models.yml
+++ b/config/mdb_models.yml
@@ -307,3 +307,17 @@ PSDC:
   latest_version: 1.0.0
   latest_prerelease_commit: 0d4ca14e2e95ce436049a62ac48afc2432902665
   latest_prerelease_version: 1.0.0
+TEST:
+  repository: CBIIT/ctos-test-model
+  mdf_directory: model-desc
+  mdf_files:
+    - test-model.yml
+    - test-model-props.yml
+  in_data_hub: false
+  versions:
+    - version: 1.0.0
+      tag: 1.0.0
+  latest_version: 1.0.0
+  latest_prerelease_commit: null
+  latest_prerelease_version: null
+  


### PR DESCRIPTION
In DATATEAM-661, we create a test MDF model at https://github.com/CBIIT/ctos-test-model. This PR updates the /config/mdb_model.yml file of the update workflow, to pull the test model into dev and QA MDBs. The test model should be treated like a pre-release model only, so that the test model doesn't get pushed to prod MDB.