### PR TITLE
DATATEAM-661

### DIFF
--- a/config/mdb_models.yml
+++ b/config/mdb_models.yml
@@ -320,6 +320,7 @@ TEST:
   mdf_files:
   - test-model.yml
   - test-model-props.yml
+  in_data_hub: false
   versions:
   - version: 1.0.0
     tag: 1.0.0

--- a/config/mdb_models.yml
+++ b/config/mdb_models.yml
@@ -321,9 +321,9 @@ TEST:
   - test-model.yml
   - test-model-props.yml
   versions:
-    - version: 1.0.0
-      tag: 1.0.0
-      ignore: true
+  - version: 1.0.0
+    tag: 1.0.0
+    ignore: true
   latest_version: null
   latest_prerelease_commit: 277d1c56e41bdec9e03947804e997ca66656477e
   latest_prerelease_version: 1.0.0

--- a/config/mdb_models.yml
+++ b/config/mdb_models.yml
@@ -313,3 +313,17 @@ PSDC:
   latest_version: 1.0.0
   latest_prerelease_commit: 0d4ca14e2e95ce436049a62ac48afc2432902665
   latest_prerelease_version: 1.0.0
+TEST:
+  repository: CBIIT/ctos-test-model
+  prerelease_repository: CBIIT/ctos-test-model
+  mdf_directory: model-desc
+  mdf_files:
+  - test-model.yml
+  - test-model-props.yml
+  versions:
+    - version: 1.0.0
+      tag: 1.0.0
+      ignore: true
+  latest_version: null
+  latest_prerelease_commit: 277d1c56e41bdec9e03947804e997ca66656477e
+  latest_prerelease_version: 1.0.0

--- a/src/bento_mdb/datatypes.py
+++ b/src/bento_mdb/datatypes.py
@@ -12,6 +12,7 @@ class ModelSpec(TypedDict):
     """CRDC model spec. Dict with model repository info and MDF file details."""
 
     repository: str
+    prerelease_repository: NotRequired[str]
     mdf_directory: str
     mdf_files: list[str | Path]
     in_data_hub: bool

--- a/src/bento_mdb/model_cdes.py
+++ b/src/bento_mdb/model_cdes.py
@@ -108,9 +108,16 @@ def get_yaml_files_from_spec(
     is_prerelease = bool(re.search(r"-[a-f0-9]{7}$", version, re.IGNORECASE))
     if is_prerelease:
         logger.info("Is prerelease version: %s", version)
-        repo = "CBIIT/crdc-datahub-models"
-        tag = "dev2"
-        mdf_directory = f"cache/{model}/{model_spec['latest_prerelease_version']}"
+        prerelease_repository = model_spec.get("prerelease_repository")
+        if prerelease_repository:
+            repo = prerelease_repository
+            tag = model_spec.get("latest_prerelease_commit")
+        else:
+            repo = "CBIIT/crdc-datahub-models"
+            tag = "dev2"
+            mdf_directory = (
+                f"cache/{model}/{model_spec['latest_prerelease_version']}"
+            )
     else:
         repo = model_spec.get("repository")
         version_entry = next(
@@ -125,6 +132,9 @@ def get_yaml_files_from_spec(
 
     if not repo:
         msg = "Model spec must have a repository."
+        raise ValueError(msg)
+    if not tag:
+        msg = "Model spec must have a tag or prerelease commit."
         raise ValueError(msg)
     if not mdf_files:
         msg = "Model spec must have file names for MDF files."

--- a/src/bento_mdb/model_cypher.py
+++ b/src/bento_mdb/model_cypher.py
@@ -56,8 +56,22 @@ def separate_shared_props(model: Model) -> None:
                 new_prop._commit = prop._commit  # noqa: SLF001
             if prop.value_set:
                 new_prop.value_set = prop.value_set.dup()
-            model.nodes[key[0]].props[key[1]] = new_prop
-            model.props[(key[0], key[1])] = new_prop
+
+            # bento-meta keys node properties as (node, prop) and relationship
+            # properties as (relationship, src, dst, prop). Use that key to
+            # replace the shared property on the exact node or relationship.
+            if len(key) == 2 and key[0] in model.nodes:
+                owner = model.nodes[key[0]]
+                prop_handle = key[1]
+            elif len(key) == 4 and key[:3] in model.edges:
+                owner = model.edges[key[:3]]
+                prop_handle = key[3]
+            else:
+                msg = f"Property owner not found for key: {key}"
+                raise ValueError(msg)
+
+            owner.props[prop_handle] = new_prop
+            model.props[key] = new_prop
         else:
             initial_props.add(prop)
 

--- a/tests/samples/test_mdf_shared_relationship_props.yml
+++ b/tests/samples/test_mdf_shared_relationship_props.yml
@@ -1,0 +1,21 @@
+Handle: TEST
+Version: 1.0.0
+Nodes:
+  sample:
+    Props: null
+  diagnosis:
+    Props: null
+  case:
+    Props: null
+Relationships:
+  of_case:
+    Props:
+      - days_to_sample
+    Ends:
+      - Src: sample
+        Dst: case
+      - Src: diagnosis
+        Dst: case
+PropDefinitions:
+  days_to_sample:
+    Type: integer

--- a/tests/test_model_cdes.py
+++ b/tests/test_model_cdes.py
@@ -113,6 +113,70 @@ class TestGetYamlFilesFromSpec:
         ]
         assert_equal(actual, expected)
 
+    def test_get_yaml_files_from_custom_prerelease_repository(self) -> None:
+        """Test that a prerelease repository override uses its commit."""
+        test_model = "TEST"
+        prerelease_commit = "277d1c56e41bdec9e03947804e997ca66656477e"
+        test_spec = ModelSpec(
+            {
+                "repository": "CBIIT/ctos-test-model",
+                "prerelease_repository": "CBIIT/ctos-test-model",
+                "mdf_directory": "model-desc",
+                "mdf_files": ["test-model.yml", "test-model-props.yml"],
+                "in_data_hub": False,
+                "versions": [
+                    {"version": "1.0.0", "tag": "1.0.0", "ignore": True},
+                ],
+                "latest_version": None,
+                "latest_prerelease_version": "1.0.0",
+                "latest_prerelease_commit": prerelease_commit,
+            },
+        )
+
+        actual = get_yaml_files_from_spec(
+            test_spec,
+            test_model,
+            "1.0.0-277d1c5",
+        )
+
+        base_url = (
+            "https://raw.githubusercontent.com/CBIIT/ctos-test-model/"
+            f"{prerelease_commit}/model-desc/"
+        )
+        expected = [base_url + str(f) for f in test_spec["mdf_files"]]
+        assert_equal(actual, expected)
+
+    def test_non_datahub_prerelease_uses_datahub_cache_by_default(self) -> None:
+        """Test that existing non-datahub prereleases keep using the cache."""
+        test_model = "TEST"
+        test_spec = ModelSpec(
+            {
+                "repository": "CBIIT/ctos-test-model",
+                "mdf_directory": "model-desc",
+                "mdf_files": ["test-model.yml", "test-model-props.yml"],
+                "in_data_hub": False,
+                "versions": [{"version": "1.0.0"}],
+                "latest_version": "1.0.0",
+                "latest_prerelease_version": "1.1.0",
+                "latest_prerelease_commit": (
+                    "277d1c56e41bdec9e03947804e997ca66656477e"
+                ),
+            },
+        )
+
+        actual = get_yaml_files_from_spec(
+            test_spec,
+            test_model,
+            "1.1.0-277d1c5",
+        )
+
+        base_url = "https://raw.githubusercontent.com/CBIIT"
+        expected = [
+            f"{base_url}/crdc-datahub-models/dev2/cache/TEST/1.1.0/test-model.yml",
+            f"{base_url}/crdc-datahub-models/dev2/cache/TEST/1.1.0/test-model-props.yml",
+        ]
+        assert_equal(actual, expected)
+
 
 class TestModelCDESpec:
     """Tests for model CDE spec."""

--- a/tests/test_model_cypher.py
+++ b/tests/test_model_cypher.py
@@ -12,6 +12,11 @@ from tests.test_utils import assert_equal, remove_nanoids_from_str
 CURRENT_DIRECTORY = Path(__file__).resolve().parent
 TEST_MODEL_MDF = Path(CURRENT_DIRECTORY, "samples", "test_mdf.yml")
 TEST_MODEL_MDF_TERMS = Path(CURRENT_DIRECTORY, "samples", "test_mdf_terms.yml")
+TEST_MODEL_MDF_SHARED_REL_PROPS = Path(
+    CURRENT_DIRECTORY,
+    "samples",
+    "test_mdf_shared_relationship_props.yml",
+)
 TEST_MODEL_MDF_USENULLCDE = Path(CURRENT_DIRECTORY, "samples", "test_mdf_useNullCDE_simple.yml")
 TEST_CHANGELOG_CONFIG = Path(CURRENT_DIRECTORY, "samples", "test_changelog.ini")
 AUTHOR = "Tolkien"
@@ -78,6 +83,29 @@ class TestMakeModelChangelog:
             "desc:'desc of id'}) MERGE (n0)-[r0:has_property]->(n1)",
         ]
         assert_equal(actual, expected)
+
+    def test_shared_relationship_props(self) -> None:
+        """Test that relationships with multiple ends get separate properties."""
+        mdf = MDF(
+            TEST_MODEL_MDF_SHARED_REL_PROPS,
+            handle=MODEL_HDL,
+            _commit=_COMMIT,
+            raise_error=True,
+        )
+        model = mdf.model
+        sample_edge = model.edges[("of_case", "sample", "case")]
+        diagnosis_edge = model.edges[("of_case", "diagnosis", "case")]
+        prop_handle = "days_to_sample"
+        assert sample_edge.props[prop_handle] is diagnosis_edge.props[prop_handle]
+
+        converter = ModelToChangelogConverter(model=model, add_rollback=False)
+        converter.convert_model_to_changelog(author=AUTHOR)
+
+        sample_prop = sample_edge.props[prop_handle]
+        diagnosis_prop = diagnosis_edge.props[prop_handle]
+        assert sample_prop is not diagnosis_prop
+        assert model.props[(*sample_edge.triplet, prop_handle)] is sample_prop
+        assert model.props[(*diagnosis_edge.triplet, prop_handle)] is diagnosis_prop
 
     def test_shared_props_with_value_set(self) -> None:
         """Test for shared properties with value_set."""


### PR DESCRIPTION
- fix(model): support test model prereleases and shared relationship props
- Resolve prerelease MDF files from an optional model-specific repository.
- Duplicate shared properties for their exact node or relationship owner.