### PR TITLE
[BUG] DATATEAM-661

### DIFF
--- a/src/bento_mdb/flows/check_promotion.py
+++ b/src/bento_mdb/flows/check_promotion.py
@@ -61,7 +61,11 @@ def _load_specs(models_filter: list[str] | None) -> dict:
     return {k: all_specs[k] for k in models_filter}
 
 
-def _query_handles(mdb: MDB, model: str, version: str) -> tuple[set, set, set]:
+def _query_handles(
+    mdb: MDB,
+    model: str,
+    version: str,
+) -> tuple[set, set, set, set]:
     logger = get_run_logger()
     p = {"model": model, "version": version}
 
@@ -82,25 +86,42 @@ def _query_handles(mdb: MDB, model: str, version: str) -> tuple[set, set, set]:
     nodes = {r["handle"] for r in _q(
         "MATCH (n:node {model:$model, version:$version}) RETURN n.handle AS handle"
     )}
-    rels = {r["handle"] for r in _q(
-        "MATCH (r:relationship {model:$model, version:$version}) RETURN r.handle AS handle"
+    rels = {(r["handle"], r["src"], r["dst"]) for r in _q(
+        "MATCH (r:relationship {model:$model, version:$version})"
+        "-[:has_src]->(src:node), (r)-[:has_dst]->(dst:node) "
+        "RETURN r.handle AS handle, src.handle AS src, dst.handle AS dst"
     )}
-    props = {(r["prop"], r["node"]) for r in _q(
+    node_props = {(r["prop"], r["node"]) for r in _q(
         "MATCH (n:node {model:$model, version:$version})-[:has_property]->"
         "(p:property {model:$model, version:$version}) "
         "RETURN p.handle AS prop, n.handle AS node"
     )}
-    return nodes, rels, props
+    rel_props = {
+        (r["handle"], r["src"], r["dst"], r["prop"])
+        for r in _q(
+            "MATCH (r:relationship {model:$model, version:$version})"
+            "-[:has_src]->(src:node), (r)-[:has_dst]->(dst:node), "
+            "(r)-[:has_property]->(p:property {model:$model, version:$version}) "
+            "RETURN r.handle AS handle, src.handle AS src, dst.handle AS dst, "
+            "p.handle AS prop"
+        )
+    }
+    return nodes, rels, node_props, rel_props
 
 
-def _load_mdf_handles(spec: dict, model: str, version: str) -> tuple[set, set, set]:
+def _load_mdf_handles(
+    spec: dict,
+    model: str,
+    version: str,
+) -> tuple[set, set, set, set]:
     urls = get_yaml_files_from_spec(spec, model, version)
     mdf = MDF(*urls, handle=model, raise_error=True, ignore_enum_by_reference=True)
     m = mdf.model
     nodes = set(m.nodes.keys())
-    rels = {k[0] for k in m.edges.keys()}
-    props = {(k[1], k[0]) for k in m.props.keys()}
-    return nodes, rels, props
+    rels = set(m.edges.keys())
+    node_props = {(k[1], k[0]) for k in m.props.keys() if len(k) == 2}
+    rel_props = {k for k in m.props.keys() if len(k) == 4}
+    return nodes, rels, node_props, rel_props
 
 
 def _log_diff(logger, label: str, a_set: set, b_set: set, a_lbl: str, b_lbl: str) -> None:
@@ -159,17 +180,31 @@ def check_model_dev(model: str, spec: dict, mdb_id: str, version: str) -> _DiffR
 
     mdb = _connect(mdb_id)
     try:
-        mdf_nodes, mdf_rels, mdf_props = _load_mdf_handles(spec, model, version)
-        mdb_nodes, mdb_rels, mdb_props = _query_handles(mdb, model, mdb_version)
+        mdf_nodes, mdf_rels, mdf_props, mdf_rel_props = _load_mdf_handles(
+            spec, model, version
+        )
+        mdb_nodes, mdb_rels, mdb_props, mdb_rel_props = _query_handles(
+            mdb, model, mdb_version
+        )
 
         _log_diff(logger, "NODES",         mdf_nodes, mdb_nodes, "MDF", "MDB-DEV")
         _log_diff(logger, "RELATIONSHIPS", mdf_rels,  mdb_rels,  "MDF", "MDB-DEV")
-        _log_diff(logger, "PROPERTIES",    mdf_props, mdb_props, "MDF", "MDB-DEV")
+        _log_diff(logger, "NODE PROPERTIES", mdf_props, mdb_props, "MDF", "MDB-DEV")
+        _log_diff(
+            logger,
+            "RELATIONSHIP PROPERTIES",
+            mdf_rel_props,
+            mdb_rel_props,
+            "MDF",
+            "MDB-DEV",
+        )
 
         inserts  = (len(mdf_nodes - mdb_nodes) + len(mdf_rels - mdb_rels)
-                    + len(mdf_props - mdb_props))
+                    + len(mdf_props - mdb_props)
+                    + len(mdf_rel_props - mdb_rel_props))
         removals = (len(mdb_nodes - mdf_nodes) + len(mdb_rels - mdf_rels)
-                    + len(mdb_props - mdf_props))
+                    + len(mdb_props - mdf_props)
+                    + len(mdb_rel_props - mdf_rel_props))
         logger.info("Expected inserts=%d  removals=%d", inserts, removals)
         if inserts == 0 and removals == 0:
             logger.info("DEV is up to date with MDF.")
@@ -189,17 +224,31 @@ def check_model_qa(model: str, spec: dict, mdb_id: str) -> _DiffResult:
 
     mdb = _connect(mdb_id)
     try:
-        mdf_nodes, mdf_rels, mdf_props = _load_mdf_handles(spec, model, version)
-        qa_nodes,  qa_rels,  qa_props  = _query_handles(mdb, model, mdb_version)
+        mdf_nodes, mdf_rels, mdf_props, mdf_rel_props = _load_mdf_handles(
+            spec, model, version
+        )
+        qa_nodes, qa_rels, qa_props, qa_rel_props = _query_handles(
+            mdb, model, mdb_version
+        )
 
         _log_diff(logger, "NODES",         mdf_nodes, qa_nodes, "MDF", f"MDB-{target_label}")
         _log_diff(logger, "RELATIONSHIPS", mdf_rels,  qa_rels,  "MDF", f"MDB-{target_label}")
-        _log_diff(logger, "PROPERTIES",    mdf_props, qa_props, "MDF", f"MDB-{target_label}")
+        _log_diff(logger, "NODE PROPERTIES", mdf_props, qa_props, "MDF", f"MDB-{target_label}")
+        _log_diff(
+            logger,
+            "RELATIONSHIP PROPERTIES",
+            mdf_rel_props,
+            qa_rel_props,
+            "MDF",
+            f"MDB-{target_label}",
+        )
 
         inserts  = (len(mdf_nodes - qa_nodes) + len(mdf_rels - qa_rels)
-                    + len(mdf_props - qa_props))
+                    + len(mdf_props - qa_props)
+                    + len(mdf_rel_props - qa_rel_props))
         removals = (len(qa_nodes - mdf_nodes) + len(qa_rels - mdf_rels)
-                    + len(qa_props - mdf_props))
+                    + len(qa_props - mdf_props)
+                    + len(qa_rel_props - mdf_rel_props))
         logger.info("Expected inserts=%d  removals=%d", inserts, removals)
         if inserts == 0 and removals == 0:
             logger.info("Expected inserts: 0; %s is fully in sync with MDF.", target_label)
@@ -221,17 +270,31 @@ def check_model_sync(model: str, spec: dict, dev_mdb_id: str, qa_mdb_id: str) ->
     mdb_dev = _connect(dev_mdb_id)
     mdb_qa  = _connect(qa_mdb_id)
     try:
-        dev_nodes, dev_rels, dev_props = _query_handles(mdb_dev, model, mdb_version)
-        qa_nodes,  qa_rels,  qa_props  = _query_handles(mdb_qa,  model, mdb_version)
+        dev_nodes, dev_rels, dev_props, dev_rel_props = _query_handles(
+            mdb_dev, model, mdb_version
+        )
+        qa_nodes, qa_rels, qa_props, qa_rel_props = _query_handles(
+            mdb_qa, model, mdb_version
+        )
 
         _log_diff(logger, "NODES",         dev_nodes, qa_nodes, source_label, target_label)
         _log_diff(logger, "RELATIONSHIPS", dev_rels,  qa_rels,  source_label, target_label)
-        _log_diff(logger, "PROPERTIES",    dev_props, qa_props, source_label, target_label)
+        _log_diff(logger, "NODE PROPERTIES", dev_props, qa_props, source_label, target_label)
+        _log_diff(
+            logger,
+            "RELATIONSHIP PROPERTIES",
+            dev_rel_props,
+            qa_rel_props,
+            source_label,
+            target_label,
+        )
 
         inserts  = (len(dev_nodes - qa_nodes) + len(dev_rels - qa_rels)
-                    + len(dev_props - qa_props))
+                    + len(dev_props - qa_props)
+                    + len(dev_rel_props - qa_rel_props))
         removals = (len(qa_nodes - dev_nodes) + len(qa_rels - dev_rels)
-                    + len(qa_props - dev_props))
+                    + len(qa_props - dev_props)
+                    + len(qa_rel_props - dev_rel_props))
         logger.info("Expected inserts=%d  removals=%d", inserts, removals)
         if inserts == 0 and removals == 0:
             logger.info("Expected inserts: 0; %s and %s are fully in sync.", source_label, target_label)

--- a/tests/test_check_promotion.py
+++ b/tests/test_check_promotion.py
@@ -19,6 +19,9 @@ import bento_mdb.flows.check_promotion as flow_module
 
 TEST_DIR = Path(__file__).resolve().parent
 SAMPLE_MDF_PATH = TEST_DIR / "samples" / "test_mdf.yml"
+SHARED_REL_PROP_MDF_PATH = (
+    TEST_DIR / "samples" / "test_mdf_shared_relationship_props.yml"
+)
 
 # test_mdf.yml: Handle TEST, Version 1.2.3, Nodes node_1..3, Relationships edge_1..2, Props prop_1..6
 SPEC = {"latest_version": "1.2.3"}
@@ -40,18 +43,47 @@ def test_load_specs_returns_subset_when_all_known() -> None:
     assert list(specs.keys()) == ["C3DC"]
 
 
+def test_load_mdf_handles_separates_relationship_properties() -> None:
+    """MDF relationship properties retain their relationship and endpoints."""
+    with patch.object(
+        flow_module,
+        "get_yaml_files_from_spec",
+        return_value=[str(SAMPLE_MDF_PATH)],
+    ):
+        _, _, props, rel_props = _load_mdf_handles(SPEC, MODEL, VERSION)
+
+    assert ("prop_6", "edge_1") not in props
+    assert props == {
+        ("prop_1", "node_1"),
+        ("prop_2", "node_1"),
+        ("prop_3", "node_2"),
+        ("prop_4", "node_2"),
+        ("prop_5", "node_3"),
+    }
+    assert rel_props == {("edge_1", "node_1", "node_2", "prop_6")}
+
+
 # ── Check 0: MDF vs DEV ──────────────────────────────────────────────────────
 
-def _make_dev_mock(nodes=None, rels=None, props=None) -> MagicMock:
-    """Mock MDB for DEV side. get_with_statement returns nodes/rels/props for diff."""
+def _make_dev_mock(nodes=None, rels=None, props=None, rel_props=None) -> MagicMock:
+    """Mock MDB query results for all structural comparison categories."""
     mock = MagicMock()
     node_rows = [{"handle": h} for h in (nodes or [])]
-    rel_rows = [{"handle": h} for h in (rels or [])]
+    rel_rows = [
+        {"handle": h, "src": src, "dst": dst}
+        for h, src, dst in (rels or [])
+    ]
     prop_rows = [{"prop": p, "node": n} for p, n in (props or [])]
+    rel_prop_rows = [
+        {"handle": h, "src": src, "dst": dst, "prop": prop}
+        for h, src, dst, prop in (rel_props or [])
+    ]
 
     def side(cypher, params):
         if "n:node" in cypher and "has_property" not in cypher:
             return node_rows
+        if "r:relationship" in cypher and "has_property" in cypher:
+            return rel_prop_rows
         if "r:relationship" in cypher:
             return rel_rows
         return prop_rows
@@ -70,17 +102,104 @@ class TestCheckModelDev:
         self, mock_connect, mock_get_yaml, mock_logger
     ) -> None:
         """MDF (real file) and DEV have same handles -> passed."""
-        mdf_nodes, mdf_rels, mdf_props = _load_mdf_handles(SPEC, MODEL, VERSION)
+        mdf_nodes, mdf_rels, mdf_props, mdf_rel_props = _load_mdf_handles(
+            SPEC, MODEL, VERSION
+        )
         mock_connect.return_value = _make_dev_mock(
             nodes=sorted(mdf_nodes),
             rels=sorted(mdf_rels),
             props=sorted(mdf_props),
+            rel_props=sorted(mdf_rel_props),
         )
         result = check_model_dev.fn(MODEL, SPEC, "dev-mdb", VERSION)
         assert result.passed
         assert result.model == MODEL
         assert result.version == VERSION
         assert result.inserts == 0 and result.removals == 0
+
+    @patch.object(flow_module, "get_run_logger")
+    @patch.object(
+        flow_module,
+        "get_yaml_files_from_spec",
+        return_value=[str(SHARED_REL_PROP_MDF_PATH)],
+    )
+    @patch.object(flow_module, "_connect")
+    def test_shared_relationship_props_do_not_fail_validation(
+        self, mock_connect, mock_get_yaml, mock_logger
+    ) -> None:
+        """TEST-style shared relationship properties do not cause false inserts."""
+        mock_connect.return_value = _make_dev_mock(
+            nodes=["sample", "diagnosis", "case"],
+            rels=[
+                ("of_case", "sample", "case"),
+                ("of_case", "diagnosis", "case"),
+            ],
+            props=[],
+            rel_props=[
+                ("of_case", "sample", "case", "days_to_sample"),
+                ("of_case", "diagnosis", "case", "days_to_sample"),
+            ],
+        )
+
+        result = check_model_dev.fn(MODEL, SPEC, "dev-mdb", VERSION)
+
+        assert result.passed
+        assert result.inserts == 0
+        assert result.removals == 0
+
+    @patch.object(flow_module, "get_run_logger")
+    @patch.object(
+        flow_module,
+        "get_yaml_files_from_spec",
+        return_value=[str(SHARED_REL_PROP_MDF_PATH)],
+    )
+    @patch.object(flow_module, "_connect")
+    def test_missing_relationship_end_fails_validation(
+        self, mock_connect, mock_get_yaml, mock_logger
+    ) -> None:
+        """A missing Src/Dst combination is detected even when its handle exists."""
+        mock_connect.return_value = _make_dev_mock(
+            nodes=["sample", "diagnosis", "case"],
+            rels=[("of_case", "sample", "case")],
+            rel_props=[
+                ("of_case", "sample", "case", "days_to_sample"),
+                ("of_case", "diagnosis", "case", "days_to_sample"),
+            ],
+        )
+
+        result = check_model_dev.fn(MODEL, SPEC, "dev-mdb", VERSION)
+
+        assert not result.passed
+        assert result.inserts == 1
+        assert result.removals == 0
+
+    @patch.object(flow_module, "get_run_logger")
+    @patch.object(
+        flow_module,
+        "get_yaml_files_from_spec",
+        return_value=[str(SHARED_REL_PROP_MDF_PATH)],
+    )
+    @patch.object(flow_module, "_connect")
+    def test_missing_relationship_property_fails_validation(
+        self, mock_connect, mock_get_yaml, mock_logger
+    ) -> None:
+        """A property missing from one relationship instance is detected."""
+        mock_connect.return_value = _make_dev_mock(
+            nodes=["sample", "diagnosis", "case"],
+            rels=[
+                ("of_case", "sample", "case"),
+                ("of_case", "diagnosis", "case"),
+            ],
+            rel_props=[
+                ("of_case", "sample", "case", "days_to_sample"),
+            ],
+        )
+
+        result = check_model_dev.fn(MODEL, SPEC, "dev-mdb", VERSION)
+
+        assert not result.passed
+        assert result.inserts == 1
+        assert result.removals == 0
 
     @patch.object(flow_module, "get_run_logger")
     @patch.object(flow_module, "get_yaml_files_from_spec", return_value=[str(SAMPLE_MDF_PATH)])
@@ -106,12 +225,15 @@ class TestCheckModelDev:
         self, mock_connect, mock_get_yaml, mock_logger
     ) -> None:
         """DEV has more than MDF (real file) -> not passed, removals>0."""
-        mdf_nodes, mdf_rels, mdf_props = _load_mdf_handles(SPEC, MODEL, VERSION)
+        mdf_nodes, mdf_rels, mdf_props, mdf_rel_props = _load_mdf_handles(
+            SPEC, MODEL, VERSION
+        )
         extra_node = "_extra_node"
         mock_connect.return_value = _make_dev_mock(
             nodes=sorted(mdf_nodes) + [extra_node],
             rels=sorted(mdf_rels),
             props=sorted(mdf_props),
+            rel_props=sorted(mdf_rel_props),
         )
         result = check_model_dev.fn(MODEL, SPEC, "dev-mdb", VERSION)
         assert not result.passed
@@ -131,11 +253,14 @@ class TestCheckModelQa:
         self, mock_connect, mock_get_yaml, mock_logger
     ) -> None:
         """MDF (real file) and QA have same handles -> passed."""
-        mdf_nodes, mdf_rels, mdf_props = _load_mdf_handles(SPEC, MODEL, VERSION)
+        mdf_nodes, mdf_rels, mdf_props, mdf_rel_props = _load_mdf_handles(
+            SPEC, MODEL, VERSION
+        )
         mock_connect.return_value = _make_dev_mock(
             nodes=sorted(mdf_nodes),
             rels=sorted(mdf_rels),
             props=sorted(mdf_props),
+            rel_props=sorted(mdf_rel_props),
         )
         result = check_model_qa.fn(MODEL, SPEC, "qa-mdb")
         assert result.passed
@@ -167,12 +292,15 @@ class TestCheckModelQa:
         self, mock_connect, mock_get_yaml, mock_logger
     ) -> None:
         """QA has more than MDF (real file) -> not passed, removals>0."""
-        mdf_nodes, mdf_rels, mdf_props = _load_mdf_handles(SPEC, MODEL, VERSION)
+        mdf_nodes, mdf_rels, mdf_props, mdf_rel_props = _load_mdf_handles(
+            SPEC, MODEL, VERSION
+        )
         extra_node = "_extra_node"
         mock_connect.return_value = _make_dev_mock(
             nodes=sorted(mdf_nodes) + [extra_node],
             rels=sorted(mdf_rels),
             props=sorted(mdf_props),
+            rel_props=sorted(mdf_rel_props),
         )
         result = check_model_qa.fn(MODEL, SPEC, "qa-mdb")
         assert not result.passed


### PR DESCRIPTION
fix(promotion): validate relationship endpoints and properties

Compare relationship triplets and relationship-owned properties across MDF and MDB.
Cover shared properties and missing endpoint or property cases.