### PR TITLE
[Hotfix] Updated MDF version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "bento-mdf>=0.13.3b1",
+    "bento-mdf>=0.13.3b2",
     "bento-meta>=0.3.2",
     "boto3>=1.38.36",
     "click>=8.1.8",
@@ -72,6 +72,3 @@ include = ["src", "scripts", "config", "data/queries"]
 markers = [
     "docker: marks tests that require docker",
 ]
-
-[tool.uv.sources]
-bento-mdf = { git = "https://github.com/CBIIT/bento-mdf.git", branch = "DATATEAM-550/read-edp-mdf", subdirectory = "python" }

--- a/uv.lock
+++ b/uv.lock
@@ -156,6 +156,7 @@ dependencies = [
     { name = "bento-meta" },
     { name = "boto3" },
     { name = "click" },
+    { name = "importlib-metadata" },
     { name = "liquichange" },
     { name = "mdb-changelog-runner" },
     { name = "minicypher" },
@@ -182,13 +183,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bento-mdf", git = "https://github.com/CBIIT/bento-mdf.git?subdirectory=python&branch=DATATEAM-550%2Fread-edp-mdf" },
+    { name = "bento-mdf", specifier = ">=0.13.3b2" },
     { name = "bento-meta", specifier = ">=0.3.2" },
     { name = "boto3", specifier = ">=1.38.36" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "docker", marker = "extra == 'dev'", specifier = ">=7.1.0" },
+    { name = "importlib-metadata", specifier = ">=6,<9" },
     { name = "liquichange", specifier = ">=0.2.1" },
-    { name = "mdb-changelog-runner", specifier = "==1.0.2" },
+    { name = "mdb-changelog-runner", specifier = "==1.0.3" },
     { name = "minicypher", specifier = ">=0.1.1" },
     { name = "neo4j", specifier = ">=4.4,<6.0" },
     { name = "packaging", specifier = ">=24.2" },
@@ -209,8 +211,8 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "bento-mdf"
-version = "0.13.3b1"
-source = { git = "https://github.com/CBIIT/bento-mdf.git?subdirectory=python&branch=DATATEAM-550%2Fread-edp-mdf#7248fca1e86551259d6dccc45ba539db3854493b" }
+version = "0.13.3b2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "bento-meta" },
@@ -228,6 +230,10 @@ dependencies = [
     { name = "tornado" },
     { name = "tqdm" },
     { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/d0/7b1130ad743c3922303b71207ea0fba24895f9304a6cdeb966541e540662/bento_mdf-0.13.3b2.tar.gz", hash = "sha256:a8506ab2331accc0407cc1c6f2f06273e23c4dbc543b76a3e898bc6052be2c7b", size = 32310, upload-time = "2026-08-03T20:57:38.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/3b/b1bb75ae6d90df2cbf3c0ce3f8a66e81ec9499772fe268176ae70512e596/bento_mdf-0.13.3b2-py3-none-any.whl", hash = "sha256:34620790f0d1338b1a04d071f086b343a4bc3ab8ea98a045d4ac021ab3ecd332", size = 37920, upload-time = "2026-08-03T20:57:37.503Z" },
 ]
 
 [[package]]
@@ -944,6 +950,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1196,15 +1214,15 @@ wheels = [
 
 [[package]]
 name = "mdb-changelog-runner"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
     { name = "neo4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/50/015c5271369c80ac160d7f241f1d5e7a24057594fe17d115f39acaf27c92/mdb_changelog_runner-1.0.2.tar.gz", hash = "sha256:31d7ca2611257c22477ffce11b1d5fa695b3d42b7546c529ce97f33cb431e10b", size = 5900, upload-time = "2026-07-06T12:50:26.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/c1/f5b1a7007fe902fe339bb0404ca8b6990c0b73d365033443e75184c4a5fa/mdb_changelog_runner-1.0.3.tar.gz", hash = "sha256:9fa81123528b3ed937e6d733624405a9300e03d6a680e07035c5844422a46cbb", size = 5916, upload-time = "2026-07-15T14:55:33.126Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/a1/7bdf7b35dafde314b044c4ba1e1d06d8c2e9faed15927719b08e38db5bd6/mdb_changelog_runner-1.0.2-py3-none-any.whl", hash = "sha256:d8e6b22fd9e9a332be19b571a541c03c3698c88e5899fdcaf8d1575dcc2c7827", size = 7942, upload-time = "2026-07-06T12:50:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/1e/b69988cced82732256b3fcc6b68d651063588171c22e551ba153cc99481e/mdb_changelog_runner-1.0.3-py3-none-any.whl", hash = "sha256:aa34851b8352aa84c22f1071583432e5ace951f7d339789f7f463ba144c8cc10", size = 7955, upload-time = "2026-07-15T14:55:32.114Z" },
 ]
 
 [[package]]
@@ -1358,8 +1376,8 @@ name = "pendulum"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "python_full_version < '3.13'" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
 wheels = [
@@ -2758,7 +2776,7 @@ name = "whenever"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/08/49181903bb52523f5e5e0b4ffc172c9bcc7edc7cda9bd626173fa99b46cf/whenever-0.7.3.tar.gz", hash = "sha256:fc2b3756c35a0694c4159ad877405949ec283623fd2082b66cdafab6e883e65b", size = 181498, upload-time = "2025-03-19T14:41:19.234Z" }
 wheels = [
@@ -2879,4 +2897,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
     { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
fix(deps): use PyPI release for bento-mdf 0.13.3b2

Remove the obsolete Git branch source and refresh the lockfile.