### PR TITLE
DATATEAM-676 Fix Bug: Link EDP enum properties to value sets

### DIFF
--- a/src/bento_mdb/model_cdes.py
+++ b/src/bento_mdb/model_cdes.py
@@ -169,7 +169,6 @@ def make_model_cde_spec(model: Model) -> ModelCDESpec:
                 # if 'caDSR' not in origin name, not a CDE
                 if "cadsr" not in term_key[1].lower():
                     continue
-                _edp_term = get_edp_enum_term(entity)
                 cde_spec["annotations"].append(
                     {
                         "entity": {
@@ -182,12 +181,7 @@ def make_model_cde_spec(model: Model) -> ModelCDESpec:
                             "attrs": term.get_attr_dict(),
                         },
                         "value_set": [],
-
-                        "edp_reference": {
-                            "origin_id": _edp_term.origin_id,
-                            "origin_name": _edp_term.origin_name,
-                            "origin_version": getattr(_edp_term, "origin_version", None),
-                        } if _edp_term else None
+                        "edp_reference": None,
                     },
                 )
     return cde_spec

--- a/src/bento_mdb/model_cypher.py
+++ b/src/bento_mdb/model_cypher.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from bento_mdb.model_cdes import get_edp_enum_term
 from bento_meta.model import Model, make_nanoid
 from bento_meta.objects import Concept, Tag
 from bento_meta.objects import Model as ModelEnt
+
 from liquichange.changelog import Changelog, Changeset, CypherChange, Rollback
 
 from bento_mdb.cypher_utils import (
@@ -21,6 +23,11 @@ if TYPE_CHECKING:
     from bento_meta.entity import Entity
 
 logger = logging.getLogger(__name__)
+
+
+def _cypher_string_literal(value: str) -> str:
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
 
 
 def add_version_to_model_ents(model: Model) -> None:
@@ -178,10 +185,55 @@ class ModelToChangelogConverter:
         self.process_tags(entity.concept)
         self.process_terms(entity.concept)
 
+    def generate_cypher_to_link_edp_value_set(self, entity: Entity) -> None:
+        """Generate cypher to link a model property to an EDP value set."""
+        edp_term = get_edp_enum_term(entity)
+        if not edp_term:
+            return
+
+        prop_attrs = entity.get_attr_dict()
+        prop_filters = [
+            f"handle: {_cypher_string_literal(prop_attrs['handle'])}",
+            f"model: {_cypher_string_literal(prop_attrs['model'])}",
+        ]
+        if prop_attrs.get("version"):
+            prop_filters.append(
+                f"version: {_cypher_string_literal(prop_attrs['version'])}",
+            )
+
+        edp_filters = [
+            f"edp.origin_name = {_cypher_string_literal(edp_term.origin_name)}",
+            f"edp.origin_id = {_cypher_string_literal(edp_term.origin_id)}",
+        ]
+        if getattr(edp_term, "origin_version", None):
+            edp_filters.append(
+                f"edp.origin_version = {_cypher_string_literal(edp_term.origin_version)}",
+            )
+
+        stmt = (
+            f"MATCH (prop:property {{{', '.join(prop_filters)}}}) "
+            f"MATCH (edp:term) "
+            f"WHERE {' AND '.join(edp_filters)} "
+            f"MATCH (edp)-[:specifies_value_set]->(vs:value_set) "
+            f"MERGE (prop)-[:has_value_set]->(vs)"
+        )
+        rollback = (
+            f"MATCH (prop:property {{{', '.join(prop_filters)}}})"
+            f"-[r:has_value_set]->(vs:value_set)<-[:specifies_value_set]-(edp:term) "
+            f"WHERE {' AND '.join(edp_filters)} "
+            f"DELETE r"
+        )
+        self.add_statement("add_rels", stmt, rollback)
+        
     def process_value_set(self, entity: Entity) -> None:
         """Generate cypher statements to merge an entity's value_set attribute."""
         if not entity.value_set:
             return
+
+        if get_edp_enum_term(entity):
+            self.generate_cypher_to_link_edp_value_set(entity)
+            return
+
         if not entity.value_set.nanoid:
             entity.value_set.nanoid = make_nanoid()
         self.generate_cypher_to_add_entity(entity.value_set)

--- a/tests/test_model_cdes.py
+++ b/tests/test_model_cdes.py
@@ -528,16 +528,17 @@ class TestMakeModelCdeSpecWithEdp:
     TEST_EDP_MODEL = Path(__file__).parent / "samples" / "test_model_edp.yml"
     TEST_EDP_PROPS = Path(__file__).parent / "samples" / "test_mdf_edp.yml"
 
-    def test_make_model_cde_spec_edp_reference_populated(self) -> None:
-        """Annotation for EDP-backed CDE should have edp_reference set."""
+    def test_make_model_cde_spec_edp_enum_does_not_populate_edp_reference(self) -> None:
+        """EDP enum references should not imply CDE-to-EDP linkage."""
         from bento_mdf.mdf import MDFReader
-        mdf = MDFReader(self.TEST_EDP_MODEL, self.TEST_EDP_PROPS, ignore_enum_by_reference=True)
+        mdf = MDFReader(
+            self.TEST_EDP_MODEL,
+            self.TEST_EDP_PROPS,
+            ignore_enum_by_reference=True,
+        )
         actual = make_model_cde_spec(mdf.model)
         assert len(actual["annotations"]) == 1
-        edp_ref = actual["annotations"][0].get("edp_reference")
-        assert edp_ref is not None
-        assert edp_ref["origin_id"] == "CRDC00005"
-        assert edp_ref["origin_name"] == "CRDC"
+        assert actual["annotations"][0].get("edp_reference") is None
 
     def test_make_model_cde_spec_edp_matches_expected(self) -> None:
         """Full spec output for EDP model matches expected structure."""

--- a/tests/test_model_cypher.py
+++ b/tests/test_model_cypher.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from bento_mdf.mdf import MDF
+from bento_mdf.mdf import MDF, MDFReader
 from bento_meta.model import Model
 from bento_meta.objects import Node, Property, Tag
 
@@ -19,6 +19,8 @@ TEST_MODEL_MDF_SHARED_REL_PROPS = Path(
 )
 TEST_MODEL_MDF_USENULLCDE = Path(CURRENT_DIRECTORY, "samples", "test_mdf_useNullCDE_simple.yml")
 TEST_CHANGELOG_CONFIG = Path(CURRENT_DIRECTORY, "samples", "test_changelog.ini")
+TEST_MODEL_EDP = Path(CURRENT_DIRECTORY, "samples", "test_model_edp.yml")
+TEST_MODEL_EDP_PROPS = Path(CURRENT_DIRECTORY, "samples", "test_mdf_edp.yml")
 AUTHOR = "Tolkien"
 MODEL_HDL = "TEST"
 _COMMIT = "_COMMIT_123"
@@ -298,3 +300,37 @@ class TestMakeModelChangelog:
         ]
 
         assert_equal(actual, expected)
+
+    def test_edp_enum_links_property_to_existing_edp_value_set(self) -> None:
+        """EDP enum references should link the property to the EDP value set."""
+        mdf = MDFReader(
+            TEST_MODEL_EDP,
+            TEST_MODEL_EDP_PROPS,
+            ignore_enum_by_reference=True,
+        )
+        converter = ModelToChangelogConverter(model=mdf.model, add_rollback=False)
+        changelog = converter.convert_model_to_changelog(
+            author=AUTHOR,
+            model_version="1.2.3",
+        )
+        actual = [
+            remove_nanoids_from_str(x.change_type.text) for x in changelog.subelements
+        ]
+
+        expected = (
+            'MATCH (prop:property {handle: "program_name", model: "TEST", version: "1.2.3"}) '
+            "MATCH (edp:term) "
+            'WHERE edp.origin_name = "CRDC" '
+            'AND edp.origin_id = "CRDC00005" '
+            'AND edp.origin_version = "1" '
+            "MATCH (edp)-[:specifies_value_set]->(vs:value_set) "
+            "MERGE (prop)-[:has_value_set]->(vs)"
+        )
+
+        assert expected in actual
+        assert not any(
+            "MATCH (n0:property" in stmt
+            and "handle:'program_name'" in stmt
+            and "MERGE (n0)-[r0:has_value_set]->(n1)" in stmt
+            for stmt in actual
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -805,11 +805,7 @@ TEST_MAKE_MODEL_CDE_SPEC_EDP = ModelCDESpec(
                     },
                 },
                 "value_set": [],
-                "edp_reference": {
-                    "origin_id": "CRDC00005",
-                    "origin_name": "CRDC",
-                    "origin_version": "1",
-                },
+                "edp_reference": None,
             },
         ],
     },


### PR DESCRIPTION
## Summary
- Link model properties that use EDP-style `Enum` references directly to the EDP value set via `has_value_set`.
- Stop inferring `caDSR CDE -> specifies_value_set -> EDP value_set` from normal model MDF usage.
- Preserve CDE-to-EDP linking for the caDSR by-reference URL mapping workflow.

## Testing
- `PYTHONPATH=src STS_URL=http://localhost:8000 uv run pytest tests/test_model_cypher.py tests/test_model_cdes.py tests/test_cde_cypher.py -q`
- `PYTHONPATH=src STS_URL=http://localhost:8000 uv run pytest --ignore=devops/awscdk -m "not docker" -q`