### PR TITLE
DATATEAM-671

### DIFF
--- a/scripts/get_pvs_and_synonyms.py
+++ b/scripts/get_pvs_and_synonyms.py
@@ -53,7 +53,7 @@ def main(model_handle: str, model_version: str, mdf_files: str | list[str]) -> N
 
     # get CDEs from model files
     logger.info("Getting CDEs from %s v%s MDFs...", model_handle, model_version)
-    mdf = MDF(*mdf_files, handle=model_handle, raise_error=True, ignore_enum_by_reference=True)
+    mdf = MDF(*mdf_files, handle=model_handle, raise_error=True)
     model = mdf.model
     (f"{model_handle} v{model_version} has {count_model_cdes(model)} CDEs.")
     model_cde_spec = make_model_cde_spec(model)

--- a/scripts/make_model_changelog.py
+++ b/scripts/make_model_changelog.py
@@ -93,7 +93,7 @@ def main(  # noqa: PLR0913
     """Get liquibase changelog from mdf files for a model."""
     logger.info("Script started")
 
-    mdf = MDF(*mdf_files, handle=model_handle, _commit=_commit, raise_error=True, ignore_enum_by_reference=True)
+    mdf = MDF(*mdf_files, handle=model_handle, _commit=_commit, raise_error=True)
     if not mdf.model:
         msg = "Error getting model from MDF"
         raise RuntimeError(msg)

--- a/src/bento_mdb/flows/check_promotion.py
+++ b/src/bento_mdb/flows/check_promotion.py
@@ -121,7 +121,7 @@ def _load_mdf_handles(
     version: str,
 ) -> tuple[set, set, set, set]:
     urls = get_yaml_files_from_spec(spec, model, version)
-    mdf = MDF(*urls, handle=model, raise_error=True, ignore_enum_by_reference=True)
+    mdf = MDF(*urls, handle=model, raise_error=True)
     m = mdf.model
     nodes = set(m.nodes.keys())
     rels = set(m.edges.keys())

--- a/tests/test_model_cdes.py
+++ b/tests/test_model_cdes.py
@@ -504,7 +504,6 @@ class TestGetEdpEnumTerm:
         mdf = MDFReader(
             self.TEST_EDP_MODEL,
             self.TEST_EDP_PROPS,
-            ignore_enum_by_reference=True,
         )
         prop = mdf.model.props[("program", "program_name")]
         result = get_edp_enum_term(prop)
@@ -534,7 +533,6 @@ class TestMakeModelCdeSpecWithEdp:
         mdf = MDFReader(
             self.TEST_EDP_MODEL,
             self.TEST_EDP_PROPS,
-            ignore_enum_by_reference=True,
         )
         actual = make_model_cde_spec(mdf.model)
         assert len(actual["annotations"]) == 1
@@ -547,7 +545,6 @@ class TestMakeModelCdeSpecWithEdp:
         mdf = MDFReader(
             self.TEST_EDP_MODEL,
             self.TEST_EDP_PROPS,
-            ignore_enum_by_reference=True,
         )
         actual = make_model_cde_spec(mdf.model)
         assert_equal(actual, TEST_MAKE_MODEL_CDE_SPEC_EDP)


### PR DESCRIPTION
fix(mdf): load referenced enum values

Resolve enum references when loading models for changelogs, CDEs, and promotion checks.